### PR TITLE
Ignore node_module by vuepress

### DIFF
--- a/.vuepress/config.yml
+++ b/.vuepress/config.yml
@@ -1,5 +1,5 @@
 title: Azure Developer College
-patterns: ['**/*.md']
+patterns: ["**/*.md", "!**/node_modules"]
 base: /trainingdays/
 themeConfig:
     repo: 'azuredevcollege/trainingdays'


### PR DESCRIPTION
This speeds up the build process if you have `node_modules` lying around.