### PR TITLE
Azure Functions - Removal of magic strings

### DIFF
--- a/day2/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
+++ b/day2/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Resources.ImageResizer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("ImageResizerFunction")]
-        public static void Run([QueueTrigger("thumbnails", Connection = "StorageAccountConnectionString")]ResizeMessage msg, 
+        [FunctionName(nameof(ImageResizer))]
+        public static void Run([QueueTrigger("thumbnails", Connection = "StorageAccountConnectionString")] ResizeMessage msg,
             ILogger log, ExecutionContext context)
         {
             _context = context;
@@ -38,7 +38,7 @@ namespace Adc.Scm.Resources.ImageResizer
             {
                 log.LogInformation(ex.Message);
             }
-            
+
 
             log.LogInformation($"Function processed: {msg}");
         }

--- a/day2/challenges/03-challenge-serverless.md
+++ b/day2/challenges/03-challenge-serverless.md
@@ -130,7 +130,7 @@ namespace AzDevCollege.Function
 {
     public static class BlobTriggerCSharp
     {
-        [FunctionName("BlobTriggerCSharp")]
+        [FunctionName(nameof(BlobTriggerCSharp))]
         public static void Run(
             [BlobTrigger("originals/{name}", Connection = "<REPLACE_WITH_NAME_OF_STORAGE_ACCOUNT>_STORAGE")]Stream myBlob, string name,
             [Blob("processed/proc_{name}", FileAccess.Write, Connection = "<REPLACE_WITH_NAME_OF_STORAGE_ACCOUNT>_STORAGE")] Stream outStream, ILogger log)

--- a/day3/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
+++ b/day3/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Resources.ImageResizer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("ImageResizerFunction")]
-        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")]ResizeMessage msg, 
+        [FunctionName(nameof(ImageResizer))]
+        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")] ResizeMessage msg,
             ILogger log, ExecutionContext context)
         {
             _context = context;
@@ -38,7 +38,7 @@ namespace Adc.Scm.Resources.ImageResizer
             {
                 log.LogInformation(ex.Message);
             }
-            
+
 
             log.LogInformation($"Function processed: {msg}");
         }

--- a/day3/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
+++ b/day3/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Search.Indexer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("SearchIndexerFunction")]
-        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)]ContactMessage msg, ILogger log, ExecutionContext context)
+        [FunctionName(nameof(ContactIndexer))]
+        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)] ContactMessage msg, ILogger log, ExecutionContext context)
         {
             _context = context;
 

--- a/day4/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
+++ b/day4/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Resources.ImageResizer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("Function1")]
-        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")]ResizeMessage msg, 
+        [FunctionName(nameof(ImageResizer))]
+        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")] ResizeMessage msg,
             ILogger log, ExecutionContext context)
         {
             _context = context;
@@ -38,7 +38,7 @@ namespace Adc.Scm.Resources.ImageResizer
             {
                 log.LogInformation(ex.Message);
             }
-            
+
 
             log.LogInformation($"Function processed: {msg}");
         }

--- a/day4/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
+++ b/day4/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Search.Indexer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("ContactIndexer")]
-        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)]ContactMessage msg, ILogger log, ExecutionContext context)
+        [FunctionName(nameof(ContactIndexer))]
+        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)] ContactMessage msg, ILogger log, ExecutionContext context)
         {
             _context = context;
 

--- a/day5/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
+++ b/day5/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Resources.ImageResizer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("Function1")]
-        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")]ResizeMessage msg, 
+        [FunctionName(nameof(ImageResizer))]
+        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")] ResizeMessage msg,
             ILogger log, ExecutionContext context)
         {
             _context = context;
@@ -38,7 +38,7 @@ namespace Adc.Scm.Resources.ImageResizer
             {
                 log.LogInformation(ex.Message);
             }
-            
+
 
             log.LogInformation($"Function processed: {msg}");
         }

--- a/day5/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
+++ b/day5/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Search.Indexer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("ContactIndexer")]
-        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)]ContactMessage msg, ILogger log, ExecutionContext context)
+        [FunctionName(nameof(ContactIndexer))]
+        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)] ContactMessage msg, ILogger log, ExecutionContext context)
         {
             _context = context;
 

--- a/day6/apps/dotnetcore/BlobTriggerFunction/BlobTriggerFunction.cs
+++ b/day6/apps/dotnetcore/BlobTriggerFunction/BlobTriggerFunction.cs
@@ -10,9 +10,9 @@ namespace AzDevCollege.Function
 {
     public static class BlobTrigger
     {
-        [FunctionName("BlobTrigge")]
+        [FunctionName(nameof(BlobTrigger))]
         public static void Run(
-            [BlobTrigger("originals/{name}", Connection = "StorageAccountConnectionString")]Stream myBlob, string name,
+            [BlobTrigger("originals/{name}", Connection = "StorageAccountConnectionString")] Stream myBlob, string name,
             [Blob("processed/proc_{name}", FileAccess.Write)] Stream outStream, ILogger log)
         {
             using (Image image = Image.Load(myBlob))

--- a/day7/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
+++ b/day7/apps/dotnetcore/Scm.Resources/Adc.Scm.Resources.ImageResizer/ImageResizer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Resources.ImageResizer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("Function1")]
-        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")]ResizeMessage msg, 
+        [FunctionName(nameof(ImageResizer))]
+        public static void Run([ServiceBusTrigger("thumbnails", Connection = "ServiceBusConnectionString")] ResizeMessage msg,
             ILogger log, ExecutionContext context)
         {
             _context = context;
@@ -38,7 +38,7 @@ namespace Adc.Scm.Resources.ImageResizer
             {
                 log.LogInformation(ex.Message);
             }
-            
+
 
             log.LogInformation($"Function processed: {msg}");
         }

--- a/day7/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
+++ b/day7/apps/dotnetcore/Scm.Search/Adc.Scm.Search.Indexer/ContactIndexer.cs
@@ -24,8 +24,8 @@ namespace Adc.Scm.Search.Indexer
             get { return _serviceProvider.Value; }
         }
 
-        [FunctionName("ContactIndexer")]
-        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)]ContactMessage msg, ILogger log, ExecutionContext context)
+        [FunctionName(nameof(ContactIndexer))]
+        public static void Run([ServiceBusTrigger("scmtopic", "scmcontactsearch", Connection = "ServiceBusConnectionString", IsSessionsEnabled = true)] ContactMessage msg, ILogger log, ExecutionContext context)
         {
             _context = context;
 

--- a/templates/dayX/challenges/NN-challenge.md
+++ b/templates/dayX/challenges/NN-challenge.md
@@ -132,7 +132,7 @@ namespace AzDevCollege.Function
 {
     public static class BlobTriggerCSharp
     {
-        [FunctionName("BlobTriggerCSharp")]
+        [FunctionName(nameof(BlobTriggerCSharp))]
         public static void Run(
             [BlobTrigger("originals/{name}", Connection = "<REPLACE_WITH_NAME_OF_STORAGE_ACCOUNT>_STORAGE")]Stream myBlob, string name,
             [Blob("processed/proc_{name}", FileAccess.Write, Connection = "<REPLACE_WITH_NAME_OF_STORAGE_ACCOUNT>_STORAGE")] Stream outStream, ILogger log)


### PR DESCRIPTION
The .NET functions used in the different days are build based on the standard template. However, it is best practice to avoid magic numbers/strings when defining the function name and use the `nameof` operator instead.

This pull request contains:
- switch to `nameof` operator for `FunctionName` (in *.cs files as well as README.md files)
- removal of `Function1` as name
- naming consistency over different days