### PR TITLE
Set environments for all deploy jobs

### DIFF
--- a/.github/workflows/day4-scm-resourcesapi.yml
+++ b/.github/workflows/day4-scm-resourcesapi.yml
@@ -185,6 +185,7 @@ jobs:
 
   deploy-resourceapi-to-dev:
     runs-on: ubuntu-latest
+    environment: day4-scm-dev
     needs: deploy-infrastructure-to-dev
 
     steps:
@@ -206,6 +207,7 @@ jobs:
 
   deploy-resizer-to-dev:
     runs-on: ubuntu-latest
+    environment: day4-scm-dev
     needs: deploy-infrastructure-to-dev
 
     steps:
@@ -273,6 +275,7 @@ jobs:
 
   deploy-resourceapi-to-test:
     runs-on: ubuntu-latest
+    environment: day4-scm-test
     needs: deploy-infrastructure-to-test
 
     steps:
@@ -294,6 +297,7 @@ jobs:
 
   deploy-resizer-to-test:
     runs-on: ubuntu-latest
+    environment: day4-scm-test
     needs: deploy-infrastructure-to-test
 
     steps:


### PR DESCRIPTION
I've set the environments for all deploy jobs only in the resource api for day4.
Let's see if a single approval still is enough to run all 3 jobs.