### PR TITLE
Updated ClusterIssuer to v1

### DIFF
--- a/day7/challenges/bonus-1.md
+++ b/day7/challenges/bonus-1.md
@@ -108,7 +108,7 @@ To define our `ClusterIssuer` we again use a YAML file that we will apply to our
 
 ```yaml
 # letsencrypt-prod-cluster-issuer.yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod


### PR DESCRIPTION
With the auto install auf cert-manager v1.6 the ClusterIssuer CRD is not available.
Received ERROR:
unable to recognize "letsencrypt-prod-cluster-issuer.yaml": no matches for kind "ClusterIssuer" in version "cert-manager.io/v1alpha2"