### PR TITLE
Fix link in pages sample

### DIFF
--- a/day4/challenges/02-github-actions-intro.md
+++ b/day4/challenges/02-github-actions-intro.md
@@ -390,7 +390,7 @@ Don't forget to add images:
 
 ![wow](https://upload.wikimedia.org/wikipedia/en/5/5f/Original_Doge_meme.jpg)
 
-and [Links](https://en.wikipedia.org/wiki/Doge_(meme)
+and [Links](https://en.wikipedia.org/wiki/Doge_(meme))
 ````
 
 ### Setting up the workflow


### PR DESCRIPTION
The wikipedia link does not work, a closing bracket is missing