### PR TITLE
Update README.md

### DIFF
--- a/day1/challenge-06/README.md
+++ b/day1/challenge-06/README.md
@@ -184,7 +184,7 @@ $servicePrincipalName = "myADCServicePrincipal$(get-random -min 100 -max 999)"  
 $jsonResult = &az ad sp create-for-rbac --name $servicePrincipalName 
 
 $SPPassword = ($jsonResult | convertfrom-json).password
-$SPName = ($jsonResult | convertfrom-json).name
+$SPName = ($jsonResult | convertfrom-json).displayName
 
 #Get your AAD ID
 $tenantID = $((Get-AzContext).Tenant.Id)  #e.g. '72f988bf-8.....'


### PR DESCRIPTION
Service Principal doesn't have property called name. It should be displayName. Corrected. 
$SPName = ($jsonResult | convertfrom-json).displayName