### PR TITLE
Day 3 - Resolve error message in Azure function

### DIFF
--- a/day3/challenges/cosmosdb/func/CosmosTrigger1/index.js
+++ b/day3/challenges/cosmosdb/func/CosmosTrigger1/index.js
@@ -30,6 +30,5 @@ module.exports = async function (context, documents) {
     if (out.length > 0) {
       context.bindings.custDocs = JSON.stringify(out)
     }
-    context.done()
   }
 }


### PR DESCRIPTION
When running the function locally and adding a new document, the following error message appears:
```
[2022-09-15T08:02:02.921Z] Error: Choose either to return a promise or call 'done'. Do not use both in your script. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909
[2022-09-15T08:02:03.094Z] Executed 'Functions.CosmosTrigger1' (Succeeded, Id=e81cf973-322c-4383-8c37-91a28820a735, Duration=7260ms)
```
Removing `context.done()` resolves this.